### PR TITLE
Fixed duplicate annotate, and spaces > tabs

### DIFF
--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -86,18 +86,17 @@ func runManifestAnnotate(dockerCli *command.DockerCli, opts annotateOptions) err
 	}
 
 	// Update the mf
-	// @TODO: Prevent duplicates
 	if opts.os != "" {
 		newMf.OS = opts.os
 	}
 	if opts.arch != "" {
 		newMf.Architecture = opts.arch
 	}
-	if len(opts.cpuFeatures) > 0 {
-		newMf.Features = append(mf.Features, opts.cpuFeatures...)
+	for _, cpuFeature := range opts.cpuFeatures {
+		newMf.Features = appendIfUnique(mf.Features, cpuFeature)
 	}
-	if len(opts.osFeatures) > 0 {
-		newMf.OSFeatures = append(mf.OSFeatures, opts.osFeatures...)
+	for _, osFeature := range opts.osFeatures {
+		newMf.OSFeatures = appendIfUnique(mf.OSFeatures, osFeature)
 	}
 	if opts.variant != "" {
 		newMf.Variant = opts.variant
@@ -116,4 +115,12 @@ func runManifestAnnotate(dockerCli *command.DockerCli, opts annotateOptions) err
 
 	logrus.Debugf("Annotated %s with options %v", mf.RefName, opts)
 	return nil
+}
+func appendIfUnique(list []string, str string) []string {
+	for _, s := range list {
+		if s == str {
+			return list
+		}
+	}
+	return append(list, str)
 }

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -68,7 +68,7 @@ func runListInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	// output basic informative details about the image
 	if len(imgInspect) == 1 {
 		// this is a basic single manifest
-		err = json.Indent(&prettyJSON, imgInspect[0].CanonicalJSON, "", "\t")
+		err = json.Indent(&prettyJSON, imgInspect[0].CanonicalJSON, "", "    ")
 		if err != nil {
 			return err
 		}
@@ -85,7 +85,7 @@ func runListInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 			return err
 		}
 		prettyJSON.Reset()
-		err = json.Indent(&prettyJSON, jsonBytes, "", "\t")
+		err = json.Indent(&prettyJSON, jsonBytes, "", "    ")
 		if err != nil {
 			return err
 		}
@@ -110,7 +110,7 @@ func runListInspect(dockerCli *command.DockerCli, opts inspectOptions) error {
 	if err != nil {
 		return err
 	}
-	err = json.Indent(&prettyJSON, jsonBytes, "", "\t")
+	err = json.Indent(&prettyJSON, jsonBytes, "", "    ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added logic to look for duplicate os / cpu features (there might be a better way to do this in go, but I couldn't find one)

Changed inspect to spaces vs tabs (might be wrong, tabs are cooler)

Deleted a redundant test for being redundant

Signed-off-by: Christopher Jones <tophj@linux.vnet.ibm.com>
